### PR TITLE
Добавил функцию в мажор sendToMpt($command, $data, $target)

### DIFF
--- a/lib/module_mdmPiTerminal.lib.php
+++ b/lib/module_mdmPiTerminal.lib.php
@@ -1,0 +1,16 @@
+<?php
+
+/* 
+ * $command команда терминалу может быть tts settings ... подробнее о командах в вики терминала https://github.com/Aculeasis/mdmTerminal2/wiki
+ * $data данные могут быть как массивом так и готовым json так и просто текстом
+ * $target системное имя терминала либо его ip
+ */
+
+function sendToMpt($command, $data, $target)  
+{
+    require(DIR_MODULES.'mdmPiTerminal/mdmPiTerminal.class.php');
+    $mpt = new  mdmPiTerminal();
+    $res = $mpt->send_mpt($command, $data, $target);
+    return $res;
+}
+?>

--- a/modules/mdmPiTerminal/mdmPiTerminal.class.php
+++ b/modules/mdmPiTerminal/mdmPiTerminal.class.php
@@ -17,7 +17,7 @@ class mdmPiTerminal extends module {
 * @access private
 */
 function mdmPiTerminal() {
-  $this->debug = 1;
+  $this->debug = 0;
   $this->name="mdmPiTerminal";
   $this->title="MDM VoiceAssistant";
   $this->module_category="<#LANG_SECTION_DEVICES#>";

--- a/modules/mdmPiTerminal/mpt_send.inc.php
+++ b/modules/mdmPiTerminal/mpt_send.inc.php
@@ -20,6 +20,19 @@
     }
     //$in= $command.':'.$senddata;
     
+    if (!filter_var($target, FILTER_VALIDATE_IP)) {
+        $tmp = SQLSelectOne("SELECT HOST FROM terminals where NAME = '$target'");
+        if($tmp['HOST'])
+        {
+            $target = $tmp['HOST'];
+        }
+        else
+        {
+            return FALSE;
+        }
+        
+    }
+    
     if($this->debug == 1) debmes("mpt send to = $target : $senddata");
         $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         if ($socket) {
@@ -29,4 +42,5 @@
             }
         }
         socket_close($socket);
+        return TRUE;
 


### PR DESCRIPTION
$command команда терминалу может быть согласно api мажора tts ...
или api терминала settings ... 
подробнее о командах в вики терминала 
https://github.com/Aculeasis/mdmTerminal2/wiki
$data данные могут быть как массивом так и готовым json так и просто текстом
$target системное имя терминала либо его ip